### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # MCP Function App Tester
+[![smithery badge](https://smithery.ai/badge/dkmaker-mcp-function-app-tester)](https://smithery.ai/server/dkmaker-mcp-function-app-tester)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 A TypeScript-based MCP server that enables testing of Azure Function Apps through Cline. This tool allows you to test and interact with Function App endpoints directly from your development environment.
@@ -9,6 +10,15 @@ A TypeScript-based MCP server that enables testing of Azure Function Apps throug
 
 ## Installation
 
+### Installing via Smithery
+
+To install Function App Tester for Claude Desktop automatically via [Smithery](https://smithery.ai/server/dkmaker-mcp-function-app-tester):
+
+```bash
+npx -y @smithery/cli install dkmaker-mcp-function-app-tester --client claude
+```
+
+### Manual Installation
 ```bash
 npm install dkmaker-mcp-function-app-tester
 ```


### PR DESCRIPTION
This PR makes two changes to the README.

1. Adds installation instructions to automatically install Function App Tester for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP.
2. Adds a badge to show the number of installations from Smithery: https://smithery.ai/server/dkmaker-mcp-function-app-tester

Let me know if any tweaks have to be made!